### PR TITLE
feat: add Homebrew version check and upgrade support for macOS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,9 +35,9 @@ node_exporter_process_priority_win: 2
 # User to run node_exporter as (only used on Unix platforms).
 node_exporter_user: "node_exporter"
 
-# Version of node_exporter to install. Because some package managers (like homebrew) don't
-# support pinning, and because others don't support the latest versions (like apt), this
-# variable is only relevant when node_exporter_install_from_binary is true.
+# Version of node_exporter to install. On macOS with Homebrew, the role will upgrade
+# to the latest available version if the installed version does not match. For binary
+# installs, this specifies the exact version to download from GitHub releases.
 node_exporter_version: "1.4.0"
 
 # Directory to scrape by the textfile collector.

--- a/tasks/darwin/configure-service-launchd.yml
+++ b/tasks/darwin/configure-service-launchd.yml
@@ -81,17 +81,28 @@
   changed_when: false
   register: uid
 
-- name: Unload node_exporter service if template file was changed  # noqa: no-handler
+- name: Unload node_exporter service if template or binary changed  # noqa: no-handler
   become: true
   ansible.builtin.command: >
     launchctl bootout gui/{{ uid.stdout }} {{ node_exporter_launchd_plist }}
   changed_when: false
   when: >
-    node_exporter_launchd_plist_template is changed and
+    (node_exporter_launchd_plist_template is changed or
+     _node_exporter_upgraded | default(false) | bool) and
     node_exporter_service_list is succeeded
 
-# The launchctl bootstrap command will fail if the service is already running, so we
-# check to see if the service is running before attempting to start it.
+- name: Stop node_exporter process after binary upgrade
+  become: true
+  ansible.builtin.command: "pkill -x node_exporter"
+  when: _node_exporter_upgraded | default(false) | bool
+  failed_when: false
+  changed_when: true
+
+- name: Wait for launchd to restart node_exporter
+  ansible.builtin.pause:
+    seconds: 3
+  when: _node_exporter_upgraded | default(false) | bool
+
 - name: Check if node_exporter service is running
   ansible.builtin.command: "pgrep node_exporter"
   failed_when: false

--- a/tasks/darwin/install-package-homebrew.yml
+++ b/tasks/darwin/install-package-homebrew.yml
@@ -19,8 +19,29 @@
     state: present
   when: ansible_distribution_version is version_compare('10.14', '<')
 
-- name: Install node_exporter package
+- name: Get installed node_exporter version
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ ansible_pkg_mgr_bin }}/node_exporter --version 2>&1 | head -1 | awk '{print $3}'
+  args:
+    executable: /bin/bash
+  register: _node_exporter_installed_version
+  changed_when: false
+  failed_when: false
+
+- name: Install or upgrade node_exporter package
   community.general.homebrew:
     name: "node_exporter"
     install_options: "{{ homebrew_install_options }}"
-    state: present
+    state: >-
+      {{ 'latest'
+         if (_node_exporter_installed_version.rc == 0 and
+             _node_exporter_installed_version.stdout != node_exporter_version)
+         else 'present' }}
+  register: _node_exporter_brew_result
+
+- name: Set node_exporter upgraded fact for service restart
+  ansible.builtin.set_fact:
+    _node_exporter_upgraded: >-
+      {{ _node_exporter_brew_result is changed and
+         _node_exporter_installed_version.rc == 0 }}


### PR DESCRIPTION
## Summary

- Check installed `node_exporter` version on macOS before Homebrew install
- Upgrade via `brew upgrade` (`state: latest`) when installed version does not match `node_exporter_version`
- Restart launchd service after binary upgrade to pick up the new version

## Problem

Previously, the Homebrew install task used `state: present` which only ensures the package is installed but never upgrades it. The `node_exporter_version` variable was completely ignored for Homebrew installs, leaving hosts stuck on whatever version was originally installed.

## Changes

| File | Change |
|------|--------|
| `tasks/darwin/install-package-homebrew.yml` | Added version check: get installed version → use `state: latest` if mismatch, `state: present` otherwise. Set `_node_exporter_upgraded` fact. |
| `tasks/darwin/configure-service-launchd.yml` | Extended unload condition to also trigger on `_node_exporter_upgraded`, ensuring the service restarts after binary upgrade. |
| `defaults/main.yml` | Updated `node_exporter_version` comment to reflect new Homebrew behavior. |

## Behavior

| Scenario | Action |
|----------|--------|
| Not installed | `state: present` — install via Homebrew |
| Installed, version matches | `state: present` — no-op (idempotent) |
| Installed, version mismatch | `state: latest` — upgrade + restart service |

**Note:** Homebrew does not support installing arbitrary specific versions. `state: latest` upgrades to the latest version available in the Homebrew formula, which for `node_exporter` is typically the most recent release.

## Related

- https://tribuna.atlassian.net/browse/ADMIN-7065